### PR TITLE
Telephony: Support muting by RIL command

### DIFF
--- a/src/com/android/services/telephony/TelephonyConnection.java
+++ b/src/com/android/services/telephony/TelephonyConnection.java
@@ -25,6 +25,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.os.PersistableBundle;
+import android.os.SystemProperties;
 import android.telecom.CallAudioState;
 import android.telecom.ConferenceParticipant;
 import android.telecom.Connection;
@@ -685,6 +686,10 @@ abstract class TelephonyConnection extends Connection implements Holdable {
         // TODO: update TTY mode.
         if (getPhone() != null) {
             getPhone().setEchoSuppressionEnabled();
+
+            if (SystemProperties.getBoolean("ro.telephony.ril.hisi", false)) {
+                getPhone().setMute(audioState.isMuted());
+            }
         }
     }
 


### PR DESCRIPTION
While almost everyone already moved to AudioManager years ago,
some OEMs (cough Huawei) still use RIL for muting and don't
promote the necessary calls in their audio HAL.
Let's handle these odd cases too when it's necessary.

Change-Id: Id916dec2574d6e57b6f809fbaf2b0959c0cc7256